### PR TITLE
rdma write modules

### DIFF
--- a/libfs/lib/spdk/test/lib/env/Makefile
+++ b/libfs/lib/spdk/test/lib/env/Makefile
@@ -34,7 +34,7 @@
 SPDK_ROOT_DIR := $(abspath $(CURDIR)/../../..)
 include $(SPDK_ROOT_DIR)/mk/spdk.common.mk
 
-DIRS-y = memory pci vtophys
+DIRS-y = memory pci
 
 .PHONY: all clean $(DIRS-y)
 

--- a/libfs/src/rdma/Makefile
+++ b/libfs/src/rdma/Makefile
@@ -1,0 +1,21 @@
+.PHONY: clean
+
+CFLAGS  := -Wall -g
+LD      := gcc
+LDLIBS  := ${LDLIBS} -lrdmacm -libverbs -lpthread
+
+APPS    := master slave
+
+all: ${APPS}
+
+master: common.o master.o
+	${LD} -o $@ $^ ${LDLIBS}
+
+slave: common.o slave.o
+	${LD} -o $@ $^ ${LDLIBS}
+
+clean:
+	rm -f *.o ${APPS}
+
+
+

--- a/libfs/src/rdma/common.c
+++ b/libfs/src/rdma/common.c
@@ -1,0 +1,203 @@
+/*The MIT License
+
+Copyright (c) 2011 Dominic Tarr
+
+Permission is hereby granted, free of charge, 
+	   to any person obtaining a copy of this software and 
+	   associated documentation files (the "Software"), to 
+	   deal in the Software without restriction, including 
+	   without limitation the rights to use, copy, modify, 
+	   merge, publish, distribute, sublicense, and/or sell 
+	   copies of the Software, and to permit persons to whom 
+	   the Software is furnished to do so, 
+	   subject to the following conditions:
+
+	   The above copyright notice and this permission notice 
+	   shall be included in all copies or substantial portions of the Software.
+
+	   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+	   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+	   OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+	   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
+	   ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+	   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+	   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.*/
+
+
+#include "common.h"
+
+struct context {
+	struct ibv_context *ctx;
+	struct ibv_pd *pd;
+	struct ibv_cq *cq;
+	struct ibv_comp_channel *comp_channel;
+
+	pthread_t cq_poller_thread;
+};
+
+static struct context *s_ctx = NULL;
+static pre_conn_cb_fn s_on_pre_conn_cb = NULL;
+static connect_cb_fn s_on_connect_cb = NULL;
+static completion_cb_fn s_on_completion_cb = NULL;
+static disconnect_cb_fn s_on_disconnect_cb = NULL;
+
+const int TIMEOUT_IN_MS = 500;
+const uint64_t LOG_SIZE = 2 * 1024 * 1024;
+
+void build_connection(struct rdma_cm_id *id)
+{
+	struct ibv_qp_init_attr qp_attr;
+
+	build_context(id->verbs);
+	build_qp_attr(&qp_attr);
+
+	rdma_create_qp(id, s_ctx->pd, &qp_attr);
+}
+
+void build_context(struct ibv_context *verbs)
+{
+	if (s_ctx) {
+		if (s_ctx->ctx != verbs)
+			rc_die("cannot handle events in more than one context.");
+
+		return;
+	}
+
+	s_ctx = (struct context *)malloc(sizeof(struct context));
+
+	s_ctx->ctx = verbs;
+
+	s_ctx->pd = ibv_alloc_pd(s_ctx->ctx);
+	s_ctx->comp_channel = ibv_create_comp_channel(s_ctx->ctx);
+	s_ctx->cq = ibv_create_cq(s_ctx->ctx, 10, NULL, s_ctx->comp_channel, 0); /* cqe=10 is arbitrary */
+	ibv_req_notify_cq(s_ctx->cq, 0);
+
+	pthread_create(&s_ctx->cq_poller_thread, NULL, poll_cq, NULL);
+}
+
+void build_params(struct rdma_conn_param *params)
+{
+	memset(params, 0, sizeof(*params));
+
+	params->initiator_depth = params->responder_resources = 1;
+	params->rnr_retry_count = 7; /* infinite retry */
+}
+
+void build_qp_attr(struct ibv_qp_init_attr *qp_attr)
+{
+	memset(qp_attr, 0, sizeof(*qp_attr));
+
+	qp_attr->send_cq = s_ctx->cq;
+	qp_attr->recv_cq = s_ctx->cq;
+	qp_attr->qp_type = IBV_QPT_RC;
+
+	qp_attr->cap.max_send_wr = 10;
+	qp_attr->cap.max_recv_wr = 10;
+	qp_attr->cap.max_send_sge = 1;
+	qp_attr->cap.max_recv_sge = 1;
+}
+
+void event_loop(struct rdma_event_channel *ec, int exit_on_disconnect)
+{
+	struct rdma_cm_event *event = NULL;
+	struct rdma_conn_param cm_params;
+
+	build_params(&cm_params);
+
+	while (rdma_get_cm_event(ec, &event) == 0) {
+		struct rdma_cm_event event_copy;
+
+		memcpy(&event_copy, event, sizeof(*event));
+		rdma_ack_cm_event(event);
+
+		if (event_copy.event == RDMA_CM_EVENT_ADDR_RESOLVED) {
+			build_connection(event_copy.id);
+
+			if (s_on_pre_conn_cb)
+				s_on_pre_conn_cb(event_copy.id);
+
+			rdma_resolve_route(event_copy.id, TIMEOUT_IN_MS);
+
+		}
+		else if (event_copy.event == RDMA_CM_EVENT_ROUTE_RESOLVED) {
+			rdma_connect(event_copy.id, &cm_params);
+
+		}
+		else if (event_copy.event == RDMA_CM_EVENT_CONNECT_REQUEST) {
+			build_connection(event_copy.id);
+
+			if (s_on_pre_conn_cb)
+				s_on_pre_conn_cb(event_copy.id);
+
+			rdma_accept(event_copy.id, &cm_params);
+
+		}
+		else if (event_copy.event == RDMA_CM_EVENT_ESTABLISHED) {
+			if (s_on_connect_cb)
+				s_on_connect_cb(event_copy.id);
+
+		}
+		else if (event_copy.event == RDMA_CM_EVENT_DISCONNECTED) {
+			rdma_destroy_qp(event_copy.id);
+
+			if (s_on_disconnect_cb)
+				s_on_disconnect_cb(event_copy.id);
+
+			rdma_destroy_id(event_copy.id);
+
+			if (exit_on_disconnect)
+				break;
+
+		}
+		else {
+			char out[19];
+			sprintf(out, "Unknown event %d \n", event_copy.event);
+			rc_die(out);
+		}
+	}
+}
+
+void * poll_cq(void *ctx)
+{
+	struct ibv_cq *cq;
+	struct ibv_wc wc;
+
+	while (1) {
+		ibv_get_cq_event(s_ctx->comp_channel, &cq, &ctx);
+		ibv_ack_cq_events(cq, 1);
+		ibv_req_notify_cq(cq, 0);
+
+		while (ibv_poll_cq(cq, 1, &wc)) {
+			if (wc.status == IBV_WC_SUCCESS)
+				s_on_completion_cb(&wc);
+			else
+				rc_die("poll_cq: status is not IBV_WC_SUCCESS");
+		}
+	}
+
+	return NULL;
+}
+
+void rc_init(pre_conn_cb_fn pc, connect_cb_fn conn, completion_cb_fn comp, disconnect_cb_fn disc)
+{
+	s_on_pre_conn_cb = pc;
+	s_on_connect_cb = conn;
+	s_on_completion_cb = comp;
+	s_on_disconnect_cb = disc;
+}
+
+void rc_disconnect(struct rdma_cm_id *id)
+{
+	rdma_disconnect(id);
+}
+
+void rc_die(const char *reason)
+{
+	fprintf(stderr, "%s\n", reason);
+	exit(EXIT_FAILURE);
+}
+
+struct ibv_pd * rc_get_pd()
+{
+	return s_ctx->pd;
+}

--- a/libfs/src/rdma/common.h
+++ b/libfs/src/rdma/common.h
@@ -1,0 +1,54 @@
+/*The MIT License
+
+Copyright (c) 2011 Dominic Tarr
+
+Permission is hereby granted, free of charge, 
+	   to any person obtaining a copy of this software and 
+	   associated documentation files (the "Software"), to 
+	   deal in the Software without restriction, including 
+	   without limitation the rights to use, copy, modify, 
+	   merge, publish, distribute, sublicense, and/or sell 
+	   copies of the Software, and to permit persons to whom 
+	   the Software is furnished to do so, 
+	   subject to the following conditions:
+
+	   The above copyright notice and this permission notice 
+	   shall be included in all copies or substantial portions of the Software.
+
+	   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+	   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+	   OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+	   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
+	   ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+	   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+	   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.*/
+
+#ifndef RDMA_COMMON_H
+#define RDMA_COMMON_H
+
+#include <netdb.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <rdma/rdma_cma.h>
+
+extern const int TIMEOUT_IN_MS;
+extern const uint64_t LOG_SIZE;
+
+typedef void(*pre_conn_cb_fn)(struct rdma_cm_id *id);
+typedef void(*connect_cb_fn)(struct rdma_cm_id *id);
+typedef void(*completion_cb_fn)(struct ibv_wc *wc);
+typedef void(*disconnect_cb_fn)(struct rdma_cm_id *id);
+
+void build_context(struct ibv_context *verbs);
+void build_qp_attr(struct ibv_qp_init_attr *qp_attr);
+void build_params(struct rdma_conn_param *params);
+void event_loop(struct rdma_event_channel *ec, int exit_on_disconnect);
+void * poll_cq(void *);
+void rc_init(pre_conn_cb_fn, connect_cb_fn, completion_cb_fn, disconnect_cb_fn);
+void rc_disconnect(struct rdma_cm_id *id);
+void rc_die(const char *message);
+struct ibv_pd * rc_get_pd();
+
+#endif

--- a/libfs/src/rdma/master.c
+++ b/libfs/src/rdma/master.c
@@ -1,0 +1,185 @@
+#include <fcntl.h>
+#include <libgen.h>
+
+#include "common.h"
+#include "messages.h"
+
+//size of rdma write - only used for testing purposes when running this module as main 
+uint64_t write_size;
+
+struct peer_context
+{
+	//start address for peer's log
+	uint64_t start_addr;
+	
+	//size of log data sync'd with remote peer
+	uint64_t synced_len;
+	
+	//peer's rdma key for specified mr
+	uint32_t rkey;
+};
+
+struct master_context
+{
+	char *log;
+	struct ibv_mr *log_mr;
+	uint64_t log_len;
+	
+	struct message *msg;
+	struct ibv_mr *msg_mr;
+
+	//TODO: to support multiple replicas, change this to an array of peer contexts
+	struct peer_context peer_ctx;
+};
+
+//issue a remote rdma write
+static void write_remote(struct rdma_cm_id *id, uint64_t local_addr, uint64_t remote_addr, uint64_t len)
+{
+	//FIXME: need to emulate NVM latency before issuing a remote write
+	//TODO: emulating NVM BW is still an open question
+
+	struct master_context *ctx = (struct master_context *)id->context;
+	struct ibv_send_wr wr, *bad_wr = NULL;
+	struct ibv_sge sge;
+
+	memset(&wr, 0, sizeof(wr));
+
+	wr.wr_id = (uintptr_t)id;
+	wr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+	wr.send_flags = IBV_SEND_SIGNALED;
+	wr.imm_data = htonl(len);
+	wr.wr.rdma.remote_addr = remote_addr;
+	wr.wr.rdma.rkey = ctx->peer_ctx.rkey;
+
+	if (len) {
+		wr.sg_list = &sge;
+		wr.num_sge = 1;
+
+		//sge.addr = (uintptr_t)ctx->log;
+		sge.addr = local_addr;
+		sge.length = len;
+		sge.lkey = ctx->log_mr->lkey;
+	}
+	ibv_post_send(id->qp, &wr, &bad_wr);
+}
+
+//call this function to sync log data to replica (based on specified id)
+static void sync_remote(struct rdma_cm_id *id)
+{
+	struct master_context *ctx = (struct master_context *)id->context;
+	uint64_t local_addr = (uintptr_t)ctx->log + ctx->peer_ctx.synced_len;
+	uint64_t remote_addr = (uintptr_t)ctx->peer_ctx.start_addr + ctx->peer_ctx.synced_len;
+	uint64_t len = ctx->log_len - ctx->peer_ctx.synced_len;
+	write_remote(id, local_addr, remote_addr, len);
+	
+	//update remote replica sync'd data info
+	ctx->peer_ctx.synced_len = ctx->peer_ctx.synced_len + len;
+}
+
+static void post_receive(struct rdma_cm_id *id)
+{
+	struct master_context *ctx = (struct master_context *)id->context;
+
+	struct ibv_recv_wr wr, *bad_wr = NULL;
+	struct ibv_sge sge;
+
+	memset(&wr, 0, sizeof(wr));
+
+	wr.wr_id = (uintptr_t)id;
+	wr.sg_list = &sge;
+	wr.num_sge = 1;
+
+	sge.addr = (uintptr_t)ctx->msg;
+	sge.length = sizeof(*ctx->msg);
+	sge.lkey = ctx->msg_mr->lkey;
+
+	ibv_post_recv(id->qp, &wr, &bad_wr);
+}
+
+static void on_pre_conn(struct rdma_cm_id *id)
+{
+	struct master_context *ctx = (struct master_context *)id->context;
+
+	posix_memalign((void **)&ctx->log, sysconf(_SC_PAGESIZE), LOG_SIZE);
+	ctx->log_mr = ibv_reg_mr(rc_get_pd(), ctx->log, LOG_SIZE, IBV_ACCESS_LOCAL_WRITE);
+
+	posix_memalign((void **)&ctx->msg, sysconf(_SC_PAGESIZE), sizeof(*ctx->msg));
+	ctx->msg_mr = ibv_reg_mr(rc_get_pd(), ctx->msg, sizeof(*ctx->msg), IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+
+	post_receive(id);
+}
+
+static void on_completion(struct ibv_wc *wc)
+{
+	struct rdma_cm_id *id = (struct rdma_cm_id *)(uintptr_t)(wc->wr_id);
+	struct master_context *ctx = (struct master_context *)id->context;
+	if (wc->opcode & IBV_WC_RECV) {
+		//printf("task received %i.\n", ctx->msg->id);
+		if (ctx->msg->id == MSG_MR) {
+			ctx->peer_ctx.start_addr = ctx->msg->data.mr.addr;
+			ctx->peer_ctx.rkey = ctx->msg->data.mr.rkey;
+			printf("received MR, sending application log(s)\n");
+			//FIXME this is only done for testing, comment out when integrating to strata
+			write_remote(id, (uintptr_t)ctx->log, ctx->peer_ctx.start_addr, write_size);
+		}
+		else if (ctx->msg->id == MSG_READY) {
+		//send empty msg to end connection once replica sends us receipt notification
+		//FIXME: this is just for testing purposes, comment out when integrating to strata
+		printf("received READY, sending empty string to end connection\n");
+		write_remote(id, (uintptr_t)ctx->log, ctx->peer_ctx.start_addr, 0);
+		}
+		else if (ctx->msg->id == MSG_DONE) {
+			printf("received DONE, disconnecting\n");
+			rc_disconnect(id);
+			return;
+		}
+
+		post_receive(id);
+	}
+}
+
+void rc_master_loop(const char *host, const char *port, void *context)
+{
+	struct addrinfo *addr;
+	struct rdma_cm_id *conn = NULL;
+	struct rdma_event_channel *ec = NULL;
+	struct rdma_conn_param cm_params;
+
+	getaddrinfo(host, port, NULL, &addr);
+
+	ec = rdma_create_event_channel();
+	rdma_create_id(ec, &conn, NULL, RDMA_PS_TCP);
+	rdma_resolve_addr(conn, NULL, addr->ai_addr, TIMEOUT_IN_MS);
+
+	freeaddrinfo(addr);
+
+	conn->context = context;
+
+	build_params(&cm_params);
+
+	event_loop(ec, 1); // exit on disconnect
+
+	rdma_destroy_event_channel(ec);
+}
+
+int main(int argc, char **argv)
+{
+	struct master_context ctx;
+
+	if (argc != 3) {
+		fprintf(stderr, "usage: %s <server-address> <write-size> \n", argv[0]);
+		return 1;
+	}
+
+	write_size = atoi(argv[2]);
+	rc_init(
+	  on_pre_conn,
+		NULL,
+		 // on connect
+		on_completion,
+		NULL); // on disconnect
+
+	  rc_master_loop(argv[1], DEFAULT_PORT, &ctx);
+
+	return 0;
+}

--- a/libfs/src/rdma/messages.h
+++ b/libfs/src/rdma/messages.h
@@ -1,0 +1,56 @@
+/*The MIT License
+
+Copyright (c) 2011 Dominic Tarr
+
+Permission is hereby granted, free of charge, 
+	   to any person obtaining a copy of this software and 
+	   associated documentation files (the "Software"), to 
+	   deal in the Software without restriction, including 
+	   without limitation the rights to use, copy, modify, 
+	   merge, publish, distribute, sublicense, and/or sell 
+	   copies of the Software, and to permit persons to whom 
+	   the Software is furnished to do so, 
+	   subject to the following conditions:
+
+	   The above copyright notice and this permission notice 
+	   shall be included in all copies or substantial portions of the Software.
+
+	   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+	   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+	   OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+	   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
+	   ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+	   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+	   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.*/
+
+#ifndef RDMA_MESSAGES_H
+#define RDMA_MESSAGES_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+const char *DEFAULT_PORT = "12345";
+
+enum message_id
+{
+	MSG_INVALID = 0,
+	MSG_MR,
+	MSG_READY,
+	MSG_DONE
+};
+
+struct message
+{
+	int id;
+
+	union
+	{
+		struct
+		{
+			uint64_t addr;
+			uint32_t rkey;
+		} mr;
+	} data;
+};
+
+#endif

--- a/libfs/src/rdma/slave.c
+++ b/libfs/src/rdma/slave.c
@@ -1,0 +1,158 @@
+#include <fcntl.h>
+#include <sys/stat.h>
+
+#include "common.h"
+#include "messages.h"
+
+struct conn_context
+{
+	char *log;
+	struct ibv_mr *log_mr;
+
+	struct message *msg;
+	struct ibv_mr *msg_mr;
+
+	int fd;
+};
+
+static void send_message(struct rdma_cm_id *id)
+{
+	struct conn_context *ctx = (struct conn_context *)id->context;
+
+	struct ibv_send_wr wr, *bad_wr = NULL;
+	struct ibv_sge sge;
+
+	memset(&wr, 0, sizeof(wr));
+
+	wr.wr_id = (uintptr_t)id;
+	wr.opcode = IBV_WR_SEND;
+	wr.sg_list = &sge;
+	wr.num_sge = 1;
+	wr.send_flags = IBV_SEND_SIGNALED;
+
+	sge.addr = (uintptr_t)ctx->msg;
+	sge.length = sizeof(*ctx->msg);
+	sge.lkey = ctx->msg_mr->lkey;
+
+	ibv_post_send(id->qp, &wr, &bad_wr);
+}
+
+static void post_receive(struct rdma_cm_id *id)
+{
+	struct ibv_recv_wr wr, *bad_wr = NULL;
+
+	memset(&wr, 0, sizeof(wr));
+
+	wr.wr_id = (uintptr_t)id;
+	wr.sg_list = NULL;
+	wr.num_sge = 0;
+
+	ibv_post_recv(id->qp, &wr, &bad_wr);
+}
+
+static void on_pre_conn(struct rdma_cm_id *id)
+{
+	struct conn_context *ctx = (struct conn_context *)malloc(sizeof(struct conn_context));
+
+	id->context = ctx;
+	
+	posix_memalign((void **)&ctx->log, sysconf(_SC_PAGESIZE), LOG_SIZE);
+	ctx->log_mr = ibv_reg_mr(rc_get_pd(), ctx->log, LOG_SIZE, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+
+	posix_memalign((void **)&ctx->msg, sysconf(_SC_PAGESIZE), sizeof(*ctx->msg));
+	ctx->msg_mr = ibv_reg_mr(rc_get_pd(), ctx->msg, sizeof(*ctx->msg), IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+
+	post_receive(id);
+}
+
+static void on_connection(struct rdma_cm_id *id)
+{
+	struct conn_context *ctx = (struct conn_context *)id->context;
+
+	ctx->msg->id = MSG_MR;
+	ctx->msg->data.mr.addr = (uintptr_t)ctx->log_mr->addr;
+	ctx->msg->data.mr.rkey = ctx->log_mr->rkey;
+
+	send_message(id);
+}
+
+static void on_completion(struct ibv_wc *wc)
+{
+	struct rdma_cm_id *id = (struct rdma_cm_id *)(uintptr_t)wc->wr_id;
+	struct conn_context *ctx = (struct conn_context *)id->context;
+
+	if (wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM) {
+		uint32_t size = ntohl(wc->imm_data);
+
+		if (size == 0) {
+			ctx->msg->id = MSG_DONE;
+			send_message(id);
+
+			// don't need post_receive() since we're done with this connection
+
+		}
+		else {
+			printf("received %i bytes.\n", size);
+			post_receive(id);
+
+			ctx->msg->id = MSG_READY;
+			send_message(id);
+		}
+	}
+}
+
+static void on_disconnect(struct rdma_cm_id *id)
+{
+	struct conn_context *ctx = (struct conn_context *)id->context;
+
+	close(ctx->fd);
+
+	ibv_dereg_mr(ctx->log_mr);
+	ibv_dereg_mr(ctx->msg_mr);
+
+	free(ctx->log);
+	free(ctx->msg);
+
+	printf("Finish transferring application log(s)");
+
+	free(ctx);
+}
+
+void* rc_slave_loop(void *port)
+{
+	struct sockaddr_in6 addr;
+	struct rdma_cm_id *listener = NULL;
+	struct rdma_event_channel *ec = NULL;
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sin6_family = AF_INET6;
+	addr.sin6_port = htons(atoi(port));
+
+	ec = rdma_create_event_channel();
+	rdma_create_id(ec, &listener, NULL, RDMA_PS_TCP);
+	rdma_bind_addr(listener, (struct sockaddr *)&addr);
+	rdma_listen(listener, 10); /* backlog=10 is arbitrary */
+
+	event_loop(ec, 0); // don't exit on disconnect
+
+	rdma_destroy_id(listener);
+	rdma_destroy_event_channel(ec);
+
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	//pthread_t server_thread;
+	rc_init(
+	  on_pre_conn,
+		on_connection,
+		on_completion,
+		on_disconnect);
+
+	printf("waiting for connections. interrupt (^C) to exit.\n");
+
+	rc_slave_loop((void*)DEFAULT_PORT);
+
+	return 0;
+}

--- a/libfs/tests/Makefile
+++ b/libfs/tests/Makefile
@@ -36,7 +36,7 @@ LDFLAGS = -Wl,-rpath=$(abspath $(GLIBC_DIR)) \
 		  -Wl,-rpath=/usr/lib/x86_64-linux-gnu/ \
 		  -Wl,-rpath=/lib/x86_64-linux-gnu/ \
 		  -Wl,-dynamic-linker=$(abspath $(GLIBC_DIR))/ld-linux-x86-64.so.2 \
-		  -lpthread -lrt -lm -lssl -lcrypto
+		  -lpthread -lrt -lm -lssl -lcrypto -lrdmacm -libverbs
 
 all: $(EXE)
 


### PR DESCRIPTION
Adding rdma write submodles for integration with remote sync. They have been removed from the strata codebase and added to their own files. The modules can be tested by running the master and slave binaries.